### PR TITLE
Changed scene loading to always capitalize the module name from file name

### DIFF
--- a/src/codegen/scenes.js
+++ b/src/codegen/scenes.js
@@ -3,6 +3,7 @@ const glob = require('glob');
 const files = glob.sync('./src/data/scenes/**/*.js');
 
 module.exports = files.map(filepath => {
-  const module_name = filepath.split('/').pop().split('.')[0];
-  return `export ${module_name} from 'data/scenes/${module_name}'`;
+  const file_name = filepath.split('/').pop().split('.')[0];
+  const module_name = file_name.charAt(0).toUpperCase() + file_name.slice(1); 
+  return `export ${module_name} from 'data/scenes/${file_name}'`;
 }).join('\n');

--- a/src/codegen/scenes.mock.js
+++ b/src/codegen/scenes.mock.js
@@ -4,7 +4,8 @@ const files = glob.sync('./src/data/scenes/**/*.js');
 
 const map = {};
 files.forEach(filepath => {
-  const module_name = filepath.split('/').pop().split('.')[0];
+  const file_name = filepath.split('/').pop().split('.')[0];
+  const module_name = file_name.charAt(0).toUpperCase() + file_name.slice(1); 
   map[module_name] = module_name;
 });
 module.exports = map;


### PR DESCRIPTION
This fixes the existing issue where it doesn't run at all, and prevents issues in the future with mixed case names (while still following React naming)